### PR TITLE
fix(output-react): default loader directory

### DIFF
--- a/packages/react-output-target/src/output-react.ts
+++ b/packages/react-output-target/src/output-react.ts
@@ -96,4 +96,4 @@ export const GENERATED_DTS = 'components.d.ts';
 const IMPORT_TYPES = 'JSX';
 const REGISTER_CUSTOM_ELEMENTS = 'defineCustomElements';
 const APPLY_POLYFILLS = 'applyPolyfills';
-const DEFAULT_LOADER_DIR = '/loader';
+const DEFAULT_LOADER_DIR = '/dist/loader';


### PR DESCRIPTION
Resolves the issue: https://github.com/ionic-team/stencil-ds-plugins/issues/49